### PR TITLE
Small Docs update - As experienced in Filament-V5

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ php artisan migrate
 php artisan make:filament-nestedset-page
 ```
 
-### Please define attribute name of the nodes in your tree, eg. title or name
+### Please define attribute name of the nodes in your tree, eg. title or name.
 
 ```php
 <?php
@@ -176,6 +176,8 @@ use Wsmallnews\FilamentNestedset\Pages\NestedsetPage;
 class Test extends NestedsetPage
 {
     ...
+    // Uncomment this in case you get this error "Property [$data] not found on component"
+    // protected ?array $data = [];
 
     protected static string $recordTitleAttribute = 'name';
     ...


### PR DESCRIPTION
While working on Filament V5 I followed the example and got the 
```php
Property [$data] not found on component: 
```
This PR adds a small note for those that may encounter a similar error and how to fix it 

<img width="1652" height="874" alt="image" src="https://github.com/user-attachments/assets/f18be5f0-39b1-4a03-b38f-63d28a2ecf63" />
