### PR TITLE
Sensible default limit for level

### DIFF
--- a/src/Pages/NestedsetPage.php
+++ b/src/Pages/NestedsetPage.php
@@ -43,7 +43,7 @@ abstract class NestedsetPage extends Page
     #[Url]
     public ?string $activeTab = null;
 
-    protected static ?int $level = null;
+    protected static ?int $level = 999;
 
     protected static ?string $emptyLabel = '';
 


### PR DESCRIPTION
```php
protected static ?int $level = null;
```

By default, having `null` as the default limit does not allow any nesting at all.

This causes a vague error message to appear which took me a while to track down, since it had no limit listed at all.

`sn-filament-nestedset::nestedset.action.move_node_failed_body_depth` => `Move node failed, the target node level cannot exceed the supported node level .`

Either the level limit should default to infinite, or have a sensible default. This PR suggests a limit of 999 which allows effectively infinite for most use cases.

```php
protected static ?int $level = 999;
```