### PR TITLE
fix: do not reject every move into a parent when $level is null

### DIFF
--- a/src/Pages/NestedsetPage.php
+++ b/src/Pages/NestedsetPage.php
@@ -242,7 +242,7 @@ abstract class NestedsetPage extends Page
                     } else {
                         // 插入指定父级, 并调整顺序
                         $parentNode = $this->getQuery()->withDepth()->findOrFail($parent);
-                        if ($parentNode->depth >= $this->getLevel() - 1) {
+                        if (! is_null($this->getLevel()) && $parentNode->depth >= $this->getLevel() - 1) {
                             Notification::make()
                                 ->danger()
                                 ->title(__('sn-filament-nestedset::nestedset.action.move_node_failed'))


### PR DESCRIPTION
# fix: do not reject every move into a parent when `$level` is null

**Target branch:** `v2` · **Branch:** `fix/null-level-move-guard` · 1 file, 1 line
**This is a backport of a condition the `v3` branch already has.**

## The problem

`$level = null` means "unlimited depth" everywhere else in the package:

- `resources/views/components/pages/nestedset-record.blade.php` —
  `$hasNextLevel = is_null($level) || $level > ($record->depth + 1)`
- `NestedsetPage::getParentSelect()` —
  `->level(is_null($this->getLevel()) ? null : ($this->getLevel() - 1))`, commented
  *"level = null 不限制"*

`moveNodeAction()` is the one place that uses it arithmetically:

```php
if ($parentNode->depth >= $this->getLevel() - 1) {
```

With a null level that is `$parentNode->depth >= -1`, which is true for **every** node in the tree.
So a page that sets no depth limit — the default — refuses every move into a parent with the
"maximum depth reached" notification, and `$action->cancel(); $action->halt();` end the action
before `prependNode()` is ever reached. Only the same-parent reordering branch above it still works,
which is a confusing symptom: dragging within a level works, dragging into a level never does, and
the notification blames a depth limit the page never set.

A page that *does* set `$level` is unaffected, which is presumably why this has survived.

## The change

```diff
--- a/src/Pages/NestedsetPage.php
+++ b/src/Pages/NestedsetPage.php
                         $parentNode = $this->getQuery()->withDepth()->findOrFail($parent);
-                        if ($parentNode->depth >= $this->getLevel() - 1) {
+                        if (! is_null($this->getLevel()) && $parentNode->depth >= $this->getLevel() - 1) {
```

This is the same guard `v3` already carries, in
`src/Filament/Pages/Concerns/HasNestedsetActions.php`:

```php
if (! is_null(static::getLevel()) && $parentNode->depth >= static::getLevel() - 1) {
```

(introduced in `26db620`, the traits restructure). So the v2 line is the only one still affected.

## Verification

Against a Filament v5 panel with a nested-set model, calling the `moveNode` action directly with a
real parent id:

| `$level` | vendor guard | result |
|---|---|---|
| `null` | unpatched | `parent_id` stays `null` — move refused |
| `null` | **patched** | `parent_id` set — move applied |
| `5` | unpatched | `parent_id` set (guard happened to pass) |

The middle row is this patch. The comparison itself is correct when a level *is* set, so only the
null case needed guarding.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
