### PR TITLE
fix: quote record keys interpolated into JavaScript expressions

### DIFF
--- a/resources/views/components/components/nestedset-record.blade.php
+++ b/resources/views/components/components/nestedset-record.blade.php
@@ -22,10 +22,10 @@
         ])
         @if ($hasChild)
             @click="isExpanded = ! isExpanded"
-            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: '{{ $record->id }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
+            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: '{{ $record->getKey() }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
             {{ $this->getRecordUrl($record) ?? 'href=javascript:;' }}
         @else
-            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: '{{ $record->id }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
+            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: '{{ $record->getKey() }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
             {{ $this->getRecordUrl($record) ?? 'href=javascript:;' }}
         @endif
     >

--- a/resources/views/components/components/nestedset-record.blade.php
+++ b/resources/views/components/components/nestedset-record.blade.php
@@ -22,10 +22,10 @@
         ])
         @if ($hasChild)
             @click="isExpanded = ! isExpanded"
-            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: {{ $record->id }}, hasChild: {{ $hasChild ? 1 : 0 }} })"
+            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: '{{ $record->id }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
             {{ $this->getRecordUrl($record) ?? 'href=javascript:;' }}
         @else
-            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: {{ $record->id }}, hasChild: {{ $hasChild ? 1 : 0 }} })"
+            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: '{{ $record->id }}', hasChild: {{ $hasChild ? 1 : 0 }} })"
             {{ $this->getRecordUrl($record) ?? 'href=javascript:;' }}
         @endif
     >

--- a/resources/views/components/pages/nestedset-record.blade.php
+++ b/resources/views/components/pages/nestedset-record.blade.php
@@ -93,7 +93,7 @@
                 wire:key="tree-item-{{ $record->getKey() }}-children"
                 data-id="{{ $record->getKey() }}"
                 x-data="treeManager({
-                    parentId: {{ $record->getKey() }}
+                    parentId: '{{ $record->getKey() }}'
                 })"
             >
                 @foreach ($record->children as $childKey => $child)


### PR DESCRIPTION
# fix: quote record keys interpolated into JavaScript expressions

**Target branch:** `v2` · **Branch:** `fix/quote-record-keys-in-js-expressions` · 2 files, 3 lines

## The problem

The tree views interpolate primary keys bare into JavaScript object literals. That is fine for
auto-increment ids, but any model with a string key (ULID, UUID, or a custom string) renders an
invalid expression:

```html
x-data="treeManager({ parentId: 01k5rq8yz3azej8n1td0pwm76 })"
```

`01k5rq8yz3azej8n1td0pwm76` is not a valid JavaScript numeric literal:

```
$ node -e "eval('({ parentId: 01k5rq8yz3azej8n1td0pwm76 })')"
SyntaxError: Invalid or unexpected token
```

So Alpine throws while initialising **every** nested container. The root container is initialised
with an empty object (`treeManager({})`) and survives, which makes this look stranger than it is:

- reordering siblings at root level works normally, so the page appears healthy;
- dragging a row *into* a parent, or *out* of one, silently does nothing — the nested containers are
  never registered as Sortable instances, so nothing in the shared `nested` group can receive them;
- rows already nested under a parent cannot be dragged at all.

A real browser reports one `Uncaught SyntaxError` per nested container on first paint.

The same bare interpolation is used for `recordId` in the menu component's two `wire:click`
dispatches, which Livewire also evaluates as JavaScript.

## The change

```diff
--- a/resources/views/components/pages/nestedset-record.blade.php
+++ b/resources/views/components/pages/nestedset-record.blade.php
                 x-data="treeManager({
-                    parentId: {{ $record->getKey() }}
+                    parentId: '{{ $record->getKey() }}'
                 })"

--- a/resources/views/components/components/nestedset-record.blade.php
+++ b/resources/views/components/components/nestedset-record.blade.php
-            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: {{ $record->id }}, ...
+            wire:click="$dispatch('sn-filament-nestedset-node-click', { recordId: '{{ $record->id }}', ...
-            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: {{ $record->id }}, ...
+            wire:click="$dispatch('sn-filament-nestedset-leaf-click', { recordId: '{{ $record->id }}', ...
```

No behaviour change for integer keys — `parentId` is only ever compared against `dataset.id`
values, which are strings on both sides already (`getSortableContainerId()` reads them straight off
the DOM), and it is sent to the server as an action argument where `$this->getQuery()->find()`
accepts either type.

If you would prefer the belt-and-braces form for keys that could themselves contain quotes,
`@js($record->getKey())` works in the same position.

## Verification

Reproduced and fixed against a real Filament v5 panel with a ULID-keyed nested-set model
(`kalnoy/nestedset` scoped tree, `HasUlids`):

- before: a Playwright-driven page load reports `Uncaught SyntaxError: Invalid or unexpected token`
  twice for a two-node tree (one per nested container), and drag-to-nest does nothing;
- after: zero JavaScript errors on the same page, and nesting/un-nesting works.

Verified by dropping the patched view into `vendor/` with our own local override removed, so the
patch is doing the work on its own.

## Note on the `v3` branch

`v3` carries the same defect in the renamed files — `parentId: {{ $record->getKey() }}` at
`resources/views/components/filament/nestedset-record.blade.php:104` (the Alpine component is
`nestedsetManager` there), and both `recordId` dispatches at
`resources/views/components/components/nestedset-record.blade.php:25,28`. Happy to open the same
patch against `v3` if useful.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
