### PR TITLE
fix: give each tree row its own $persist key for its collapsed state

### DIFF
--- a/resources/views/components/pages/nestedset-record.blade.php
+++ b/resources/views/components/pages/nestedset-record.blade.php
@@ -17,7 +17,7 @@
 @endphp
 
 <div
-    x-data="{ open: $persist(true) }"
+    x-data="{ open: $persist(true).as('sn-tree-{{ $record->getKey() }}') }"
     wire:key="tree-item-{{ $record->getKey() }}"
     data-id="{{ $record->getKey() }}"
     class="fi-sn-tree-item"


### PR DESCRIPTION
# fix: give each tree row its own `$persist` key for its collapsed state

**Target branch:** `v2` · **Branch:** `fix/per-row-persist-key` · 1 file, 1 line

## The problem

Every row renders the same persisted property:

```html
<div x-data="{ open: $persist(true) }" ...>
```

Without `.as()`, Alpine's persist plugin derives the storage key from the property path alone:

```js
// @alpinejs/persist
let lookup = alias || `_x_${path}`
```

`path` here is just `open`, so every row in the tree — at every depth — reads and writes the single
`_x_open` entry in `localStorage`.

Each row still has its own Alpine component, so the immediate click looks right: collapsing one
branch collapses only that branch. The shared entry surfaces on the **next page load**, when every
row initialises from the last value any row happened to write — so one collapsed branch collapses
the entire tree, and expanding any branch expands all of them.

Filament's own components pass `.as()` for this reason
(`$persist(true).as('isOpen')`, `.as('collapsedGroups')` in the sidebar).

## The change

```diff
--- a/resources/views/components/pages/nestedset-record.blade.php
+++ b/resources/views/components/pages/nestedset-record.blade.php
 <div
-    x-data="{ open: $persist(true) }"
+    x-data="{ open: $persist(true).as('sn-tree-{{ $record->getKey() }}') }"
     wire:key="tree-item-{{ $record->getKey() }}"
```

`sn-tree-` matches the package's existing `fi-sn-tree-*` class naming. Note `.as()` *replaces* the
key rather than prefixing it, so the stored key is the alias verbatim — no `_x_` prefix.

Existing installs lose their persisted expand/collapse state once, on first load after upgrading,
and default back to expanded. Worth a line in the changelog.

## Verification

Against a Filament v5 panel with two sibling branches, each with one child:

- before: no per-row keys exist; a single `_x_open` entry is shared by all four rows;
- after: `localStorage` holds a distinct `sn-tree-<key>` entry per row, asserted for both branch
  keys in a browser test. Reverting the one line makes that assertion fail again.

## Note on the `v3` branch

`v3` has the same bare `$persist(true)` at
`resources/views/components/filament/nestedset-record.blade.php:21`. Happy to open the same patch
against `v3` if useful.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
